### PR TITLE
✨ Add GitHub activity contest feature with collapsible commit feed

### DIFF
--- a/app/css/index.css
+++ b/app/css/index.css
@@ -49,6 +49,372 @@ a:hover {
   color: white;
 }
 
+#github-commits-section {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  margin: 16px 0;
+  width: 50%;
+  color: white;
+}
+
+.section-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  gap: 16px;
+}
+
+#github-commits-section .notice {
+  border-bottom: 1px solid white;
+  font-size: 40px;
+  padding: 8px;
+  text-align: center;
+  flex: 1;
+}
+
+.header-controls {
+  display: flex;
+  gap: 12px;
+}
+
+.control-button {
+  background-color: #2d3748;
+  border: 2px solid #523D91;
+  border-radius: 8px;
+  color: white;
+  cursor: pointer;
+  font-size: 20px;
+  padding: 10px 16px;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.control-button:hover {
+  background-color: #523D91;
+  transform: scale(1.1);
+}
+
+.github-content {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-height: 3000px;
+  overflow: visible;
+  transition: max-height 0.5s ease-in-out, opacity 0.5s ease-in-out;
+  opacity: 1;
+}
+
+.github-content.collapsed {
+  max-height: 0;
+  opacity: 0;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+#github-users-tabs {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.github-tab {
+  background-color: #2d3748;
+  border: 2px solid #523D91;
+  border-radius: 8px;
+  color: white;
+  cursor: pointer;
+  font-family: 'Amazon Ember', sans-serif;
+  font-size: 16px;
+  padding: 12px 24px;
+  transition: all 0.3s ease;
+}
+
+.github-tab:hover {
+  background-color: #523D91;
+  transform: scale(1.05);
+}
+
+.github-tab.active {
+  background-color: #7b02e0;
+  box-shadow: 0 0 10px #7b02e0;
+}
+
+#github-chart-container {
+  width: 100%;
+  margin-bottom: 16px;
+}
+
+.github-profile-link {
+  display: block;
+  width: 100%;
+}
+
+.github-chart-card {
+  align-items: center;
+  background-color: #161E2D;
+  border-radius: 16px;
+  display: flex;
+  gap: 24px;
+  padding: 24px;
+  box-shadow: -2px -2px 10px #7b02e0, 2px 2px 10px #ffffff;
+  transition: transform 0.3s ease;
+}
+
+.github-chart-card:hover {
+  transform: scale(1.02);
+}
+
+.github-avatar {
+  border-radius: 50%;
+  border: 3px solid #523D91;
+  height: 100px;
+  width: 100px;
+  object-fit: cover;
+}
+
+.github-user-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.github-user-info h3 {
+  margin: 0;
+  font-size: 24px;
+  color: #7b02e0;
+}
+
+.github-bio {
+  margin: 0;
+  font-size: 14px;
+  color: #c5bfbf;
+  line-height: 1.5;
+}
+
+.github-stats {
+  display: flex;
+  gap: 24px;
+  margin-top: 8px;
+}
+
+.github-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.stat-value {
+  font-size: 20px;
+  font-weight: bold;
+  color: #7b02e0;
+}
+
+.stat-label {
+  font-size: 12px;
+  color: #c5bfbf;
+  text-transform: uppercase;
+}
+
+#github-commits-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+}
+
+.scrollable-commits {
+  max-height: 400px;
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+.scrollable-commits::-webkit-scrollbar {
+  width: 8px;
+}
+
+.scrollable-commits::-webkit-scrollbar-track {
+  background: #2d3748;
+  border-radius: 4px;
+}
+
+.scrollable-commits::-webkit-scrollbar-thumb {
+  background: #523D91;
+  border-radius: 4px;
+}
+
+.scrollable-commits::-webkit-scrollbar-thumb:hover {
+  background: #7b02e0;
+}
+
+.commit-card {
+  background-color: #161E2D;
+  border-radius: 12px;
+  padding: 16px;
+  transition: all 0.3s ease;
+  display: block;
+  box-shadow: -1px -1px 5px #460a6e, 1px 1px 5px #ffffff;
+}
+
+.commit-card:hover {
+  transform: translateX(8px);
+  box-shadow: -2px -2px 10px #7b02e0, 2px 2px 10px #ffffff;
+}
+
+.commit-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.commit-repo {
+  color: #7b02e0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.commit-sha {
+  background-color: #2d3748;
+  border-radius: 4px;
+  color: #c5bfbf;
+  font-family: monospace;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+
+.commit-message {
+  color: white;
+  font-size: 16px;
+  margin: 8px 0;
+  line-height: 1.4;
+}
+
+.commit-stats {
+  display: flex;
+  gap: 12px;
+  margin: 8px 0;
+  font-size: 12px;
+  font-family: monospace;
+}
+
+.commit-additions {
+  color: #4ade80;
+  font-weight: 600;
+}
+
+.commit-deletions {
+  color: #f87171;
+  font-weight: 600;
+}
+
+.commit-date {
+  color: #c5bfbf;
+  font-size: 12px;
+}
+
+.loading, .no-commits {
+  color: #c5bfbf;
+  font-size: 16px;
+  text-align: center;
+  padding: 24px;
+}
+
+/* Contest Scoreboard Styles */
+.scoreboard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  width: 100%;
+  padding: 24px;
+  background: linear-gradient(135deg, #161E2D 0%, #2d3748 100%);
+  border-radius: 16px;
+  box-shadow: -2px -2px 10px #7b02e0, 2px 2px 10px #ffffff;
+}
+
+.contest-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 20px;
+  background-color: #161E2D;
+  border-radius: 12px;
+  border: 2px solid #523D91;
+  transition: all 0.3s ease;
+}
+
+.contest-card.winner {
+  border-color: #7b02e0;
+  box-shadow: 0 0 20px #7b02e0;
+  transform: scale(1.05);
+}
+
+.contest-username {
+  margin: 0;
+  font-size: 20px;
+  color: white;
+  font-weight: 600;
+}
+
+.contest-score {
+  font-size: 48px;
+  font-weight: bold;
+  background: linear-gradient(135deg, #7b02e0 0%, #523D91 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.contest-card.winner .contest-score {
+  background: linear-gradient(135deg, #ffd700 0%, #ffed4e 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.contest-stats {
+  display: flex;
+  gap: 20px;
+  margin-top: 8px;
+}
+
+.contest-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.contest-stat-value {
+  font-size: 18px;
+  font-weight: bold;
+  color: #7b02e0;
+}
+
+.contest-stat-label {
+  font-size: 11px;
+  color: #c5bfbf;
+  text-transform: uppercase;
+  margin-top: 4px;
+}
+
+.vs-divider {
+  font-size: 32px;
+  font-weight: bold;
+  color: #7b02e0;
+  padding: 0 16px;
+  text-shadow: 0 0 10px #7b02e0;
+}
+
 #sponsors-section {
   align-items: center;
   display: flex;
@@ -189,10 +555,103 @@ a:hover {
     height: auto;
   }
 
-  #newsfeed, #newsfeed-past, #sponsors-section {
+  #newsfeed, #newsfeed-past, #sponsors-section, #github-commits-section {
     width: 90%;
     gap: 32px;
     margin: 12px 0;
+  }
+
+  .section-header {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  #github-commits-section .notice {
+    font-size: 28px;
+    padding: 6px;
+  }
+
+  .header-controls {
+    gap: 8px;
+  }
+
+  .control-button {
+    font-size: 18px;
+    padding: 8px 14px;
+  }
+
+  #github-users-tabs {
+    gap: 12px;
+  }
+
+  .github-tab {
+    font-size: 14px;
+    padding: 10px 20px;
+  }
+
+  .scoreboard {
+    flex-direction: column;
+    gap: 16px;
+    padding: 16px;
+  }
+
+  .contest-card {
+    width: 100%;
+  }
+
+  .vs-divider {
+    font-size: 24px;
+    padding: 8px 0;
+  }
+
+  .contest-score {
+    font-size: 36px;
+  }
+
+  .scrollable-commits {
+    max-height: 300px;
+  }
+
+  .github-chart-card {
+    flex-direction: column;
+    gap: 16px;
+    padding: 16px;
+  }
+
+  .github-avatar {
+    height: 80px;
+    width: 80px;
+  }
+
+  .github-user-info h3 {
+    font-size: 20px;
+    text-align: center;
+  }
+
+  .github-bio {
+    font-size: 13px;
+    text-align: center;
+  }
+
+  .github-stats {
+    gap: 16px;
+    justify-content: center;
+  }
+
+  .stat-value {
+    font-size: 18px;
+  }
+
+  .commit-card {
+    padding: 12px;
+  }
+
+  .commit-repo {
+    font-size: 13px;
+  }
+
+  .commit-message {
+    font-size: 14px;
   }
 
   #sponsors-container {
@@ -241,10 +700,108 @@ a:hover {
     max-width: 95%;
   }
 
-  #newsfeed, #newsfeed-past, #sponsors-section {
+  #newsfeed, #newsfeed-past, #sponsors-section, #github-commits-section {
     width: 95%;
     gap: 24px;
     margin: 8px 0;
+  }
+
+  .section-header {
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  #github-commits-section .notice {
+    font-size: 22px;
+    padding: 4px;
+  }
+
+  .control-button {
+    font-size: 16px;
+    padding: 6px 12px;
+  }
+
+  #github-users-tabs {
+    gap: 8px;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .github-tab {
+    font-size: 13px;
+    padding: 8px 16px;
+    width: 100%;
+  }
+
+  .scoreboard {
+    padding: 12px;
+    gap: 12px;
+  }
+
+  .contest-card {
+    padding: 16px;
+  }
+
+  .contest-score {
+    font-size: 32px;
+  }
+
+  .contest-username {
+    font-size: 16px;
+  }
+
+  .contest-stat-value {
+    font-size: 16px;
+  }
+
+  .contest-stat-label {
+    font-size: 10px;
+  }
+
+  .scrollable-commits {
+    max-height: 250px;
+  }
+
+  .github-avatar {
+    height: 70px;
+    width: 70px;
+  }
+
+  .github-user-info h3 {
+    font-size: 18px;
+  }
+
+  .github-bio {
+    font-size: 12px;
+  }
+
+  .github-stats {
+    gap: 12px;
+  }
+
+  .stat-value {
+    font-size: 16px;
+  }
+
+  .stat-label {
+    font-size: 10px;
+  }
+
+  .commit-card {
+    padding: 10px;
+  }
+
+  .commit-repo {
+    font-size: 12px;
+  }
+
+  .commit-message {
+    font-size: 13px;
+  }
+
+  .commit-sha {
+    font-size: 10px;
+    padding: 3px 6px;
   }
 
   #sponsors-container {

--- a/app/index.html
+++ b/app/index.html
@@ -20,6 +20,28 @@
       </a>
     </div>
     <div class="content">
+      <div id="github-commits-section">
+        <div class="section-header">
+          <span class="notice">GitHub Activity Contest</span>
+          <div class="header-controls">
+            <button id="toggle-github-section" class="control-button" aria-label="Toggle GitHub section">
+              <i class="fa fa-chevron-up"></i>
+            </button>
+            <a href="#newsfeed" class="control-button jump-button" aria-label="Jump to newsfeed">
+              <i class="fa fa-arrow-down"></i>
+            </a>
+          </div>
+        </div>
+        <div id="github-section-content" class="github-content">
+          <div id="contest-scoreboard"></div>
+          <div id="github-users-tabs">
+            <button class="github-tab active" data-user="tnielsen2">tnielsen2</button>
+            <button class="github-tab" data-user="wheeleruniverse">wheeleruniverse</button>
+          </div>
+          <div id="github-chart-container"></div>
+          <div id="github-commits-container" class="scrollable-commits"></div>
+        </div>
+      </div>
       <div id="newsfeed"></div>
       <div id="sponsors-section">
         <span class="notice">Our Previous Sponsors</span>

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -1,5 +1,11 @@
 import { newsFeedEntries, sponsors } from './data.js';
 
+let currentGithubUser = 'tnielsen2';
+let contestData = {
+  tnielsen2: { commits: 0, linesChanged: 0, score: 0 },
+  wheeleruniverse: { commits: 0, linesChanged: 0, score: 0 }
+};
+
 function onScroll() {
   const scrollCtrl = document.getElementById('scroll-ctrl');
   scrollCtrl.style.display =
@@ -53,7 +59,7 @@ function populateNewsFeed() {
 
 function populateSponsors() {
   const sponsorsContainer = document.getElementById('sponsors-container');
-  
+
   // Sort sponsors alphabetically by name
   const sortedSponsors = [...sponsors].sort((a, b) => a.name.localeCompare(b.name));
 
@@ -78,9 +84,387 @@ function populateSponsors() {
   });
 }
 
+async function fetchGitHubCommits(username) {
+  try {
+    // Fetch user's events (includes commits)
+    const response = await fetch(`https://api.github.com/users/${username}/events/public?per_page=100`);
+    if (!response.ok) throw new Error('Failed to fetch commits');
+
+    const events = await response.json();
+
+    // Filter for push events and extract commits
+    const commits = [];
+    let totalLinesChanged = 0;
+
+    events.forEach(event => {
+      if (event.type === 'PushEvent' && event.payload.commits) {
+        event.payload.commits.forEach(commit => {
+          // Estimate lines changed (GitHub API doesn't provide this in events)
+          // We'll fetch detailed commit info for accuracy
+          commits.push({
+            message: commit.message,
+            sha: commit.sha.substring(0, 7),
+            fullSha: commit.sha,
+            repo: event.repo.name,
+            repoUrl: `https://github.com/${event.repo.name}`,
+            commitUrl: `https://github.com/${event.repo.name}/commit/${commit.sha}`,
+            date: new Date(event.created_at),
+            author: commit.author.name
+          });
+        });
+      }
+    });
+
+    // Sort by date (most recent first)
+    const sortedCommits = commits.sort((a, b) => b.date - a.date);
+
+    // Fetch detailed stats for commits (limit to avoid rate limiting)
+    const detailedCommits = await Promise.all(
+      sortedCommits.slice(0, 15).map(async (commit) => {
+        try {
+          const detailResponse = await fetch(`https://api.github.com/repos/${commit.repo}/commits/${commit.fullSha}`);
+          if (detailResponse.ok) {
+            const detail = await detailResponse.json();
+            const additions = detail.stats?.additions || 0;
+            const deletions = detail.stats?.deletions || 0;
+            totalLinesChanged += additions + deletions;
+            return { ...commit, additions, deletions, linesChanged: additions + deletions };
+          }
+        } catch (err) {
+          console.warn('Could not fetch commit details:', err);
+        }
+        return { ...commit, additions: 0, deletions: 0, linesChanged: 0 };
+      })
+    );
+
+    // Update contest data
+    contestData[username].commits = sortedCommits.length;
+    contestData[username].linesChanged = totalLinesChanged;
+
+    return detailedCommits;
+  } catch (error) {
+    console.error('Error fetching GitHub commits:', error);
+    return [];
+  }
+}
+
+async function fetchGitHubContributions(username) {
+  try {
+    // Fetch user info for contribution data
+    const response = await fetch(`https://api.github.com/users/${username}`);
+    if (!response.ok) throw new Error('Failed to fetch user data');
+
+    const userData = await response.json();
+    return {
+      publicRepos: userData.public_repos,
+      followers: userData.followers,
+      following: userData.following,
+      profileUrl: userData.html_url,
+      avatarUrl: userData.avatar_url,
+      bio: userData.bio,
+      name: userData.name || username
+    };
+  } catch (error) {
+    console.error('Error fetching GitHub user data:', error);
+    return null;
+  }
+}
+
+function renderGitHubChart(userData) {
+  const chartContainer = document.getElementById('github-chart-container');
+  chartContainer.innerHTML = '';
+
+  if (!userData) return;
+
+  const chartCard = document.createElement('div');
+  chartCard.classList.add('github-chart-card');
+
+  const avatar = document.createElement('img');
+  avatar.classList.add('github-avatar');
+  avatar.src = userData.avatarUrl;
+  avatar.alt = userData.name;
+
+  const userInfo = document.createElement('div');
+  userInfo.classList.add('github-user-info');
+
+  const userName = document.createElement('h3');
+  userName.textContent = userData.name;
+
+  const userBio = document.createElement('p');
+  userBio.classList.add('github-bio');
+  userBio.textContent = userData.bio || 'No bio available';
+
+  const statsContainer = document.createElement('div');
+  statsContainer.classList.add('github-stats');
+
+  const reposStat = document.createElement('div');
+  reposStat.classList.add('github-stat');
+  reposStat.innerHTML = `<span class="stat-value">${userData.publicRepos}</span><span class="stat-label">Repos</span>`;
+
+  const followersStat = document.createElement('div');
+  followersStat.classList.add('github-stat');
+  followersStat.innerHTML = `<span class="stat-value">${userData.followers}</span><span class="stat-label">Followers</span>`;
+
+  const followingStat = document.createElement('div');
+  followingStat.classList.add('github-stat');
+  followingStat.innerHTML = `<span class="stat-value">${userData.following}</span><span class="stat-label">Following</span>`;
+
+  statsContainer.appendChild(reposStat);
+  statsContainer.appendChild(followersStat);
+  statsContainer.appendChild(followingStat);
+
+  userInfo.appendChild(userName);
+  userInfo.appendChild(userBio);
+  userInfo.appendChild(statsContainer);
+
+  chartCard.appendChild(avatar);
+  chartCard.appendChild(userInfo);
+
+  const profileLink = document.createElement('a');
+  profileLink.href = userData.profileUrl;
+  profileLink.target = '_blank';
+  profileLink.classList.add('github-profile-link');
+  profileLink.appendChild(chartCard);
+
+  chartContainer.appendChild(profileLink);
+}
+
+function calculateContestScore(commits, linesChanged) {
+  // Normalization formula: Score = (0.6 * normalized_commits) + (0.4 * normalized_lines)
+  // This gives more weight to commits but still values lines changed
+  const maxCommits = 100;
+  const maxLines = 10000;
+
+  const normalizedCommits = Math.min(commits / maxCommits, 1);
+  const normalizedLines = Math.min(linesChanged / maxLines, 1);
+
+  return Math.round((0.6 * normalizedCommits + 0.4 * normalizedLines) * 1000);
+}
+
+function renderContestScoreboard() {
+  const scoreboardContainer = document.getElementById('contest-scoreboard');
+  scoreboardContainer.innerHTML = '';
+
+  // Calculate scores
+  contestData.tnielsen2.score = calculateContestScore(
+    contestData.tnielsen2.commits,
+    contestData.tnielsen2.linesChanged
+  );
+  contestData.wheeleruniverse.score = calculateContestScore(
+    contestData.wheeleruniverse.commits,
+    contestData.wheeleruniverse.linesChanged
+  );
+
+  const scoreboard = document.createElement('div');
+  scoreboard.classList.add('scoreboard');
+
+  // User 1 card
+  const user1Card = createContestCard('tnielsen2', contestData.tnielsen2);
+
+  // VS divider
+  const vsDivider = document.createElement('div');
+  vsDivider.classList.add('vs-divider');
+  vsDivider.textContent = 'VS';
+
+  // User 2 card
+  const user2Card = createContestCard('wheeleruniverse', contestData.wheeleruniverse);
+
+  scoreboard.appendChild(user1Card);
+  scoreboard.appendChild(vsDivider);
+  scoreboard.appendChild(user2Card);
+
+  scoreboardContainer.appendChild(scoreboard);
+}
+
+function createContestCard(username, data) {
+  const card = document.createElement('div');
+  card.classList.add('contest-card');
+
+  // Determine if winner
+  const isWinner = data.score > contestData[username === 'tnielsen2' ? 'wheeleruniverse' : 'tnielsen2'].score;
+  if (isWinner && data.score > 0) {
+    card.classList.add('winner');
+  }
+
+  const usernameEl = document.createElement('h4');
+  usernameEl.classList.add('contest-username');
+  usernameEl.textContent = username;
+
+  const scoreEl = document.createElement('div');
+  scoreEl.classList.add('contest-score');
+  scoreEl.textContent = data.score;
+
+  const statsEl = document.createElement('div');
+  statsEl.classList.add('contest-stats');
+  statsEl.innerHTML = `
+    <div class="contest-stat">
+      <span class="contest-stat-value">${data.commits}</span>
+      <span class="contest-stat-label">Commits</span>
+    </div>
+    <div class="contest-stat">
+      <span class="contest-stat-value">${data.linesChanged.toLocaleString()}</span>
+      <span class="contest-stat-label">Lines Changed</span>
+    </div>
+  `;
+
+  card.appendChild(usernameEl);
+  card.appendChild(scoreEl);
+  card.appendChild(statsEl);
+
+  return card;
+}
+
+function renderGitHubCommits(commits) {
+  const commitsContainer = document.getElementById('github-commits-container');
+  commitsContainer.innerHTML = '';
+
+  if (commits.length === 0) {
+    const noCommits = document.createElement('p');
+    noCommits.classList.add('no-commits');
+    noCommits.textContent = 'No recent commits found';
+    commitsContainer.appendChild(noCommits);
+    return;
+  }
+
+  commits.forEach(commit => {
+    const commitCard = document.createElement('a');
+    commitCard.classList.add('commit-card');
+    commitCard.href = commit.commitUrl;
+    commitCard.target = '_blank';
+
+    const commitHeader = document.createElement('div');
+    commitHeader.classList.add('commit-header');
+
+    const commitRepo = document.createElement('span');
+    commitRepo.classList.add('commit-repo');
+    commitRepo.textContent = commit.repo;
+
+    const commitSha = document.createElement('span');
+    commitSha.classList.add('commit-sha');
+    commitSha.textContent = commit.sha;
+
+    commitHeader.appendChild(commitRepo);
+    commitHeader.appendChild(commitSha);
+
+    const commitMessage = document.createElement('p');
+    commitMessage.classList.add('commit-message');
+    commitMessage.textContent = commit.message.split('\n')[0]; // First line only
+
+    const commitStats = document.createElement('div');
+    commitStats.classList.add('commit-stats');
+
+    if (commit.linesChanged > 0) {
+      const additions = document.createElement('span');
+      additions.classList.add('commit-additions');
+      additions.textContent = `+${commit.additions}`;
+
+      const deletions = document.createElement('span');
+      deletions.classList.add('commit-deletions');
+      deletions.textContent = `-${commit.deletions}`;
+
+      commitStats.appendChild(additions);
+      commitStats.appendChild(deletions);
+    }
+
+    const commitDate = document.createElement('span');
+    commitDate.classList.add('commit-date');
+    commitDate.textContent = formatDate(commit.date);
+
+    commitCard.appendChild(commitHeader);
+    commitCard.appendChild(commitMessage);
+    commitCard.appendChild(commitStats);
+    commitCard.appendChild(commitDate);
+
+    commitsContainer.appendChild(commitCard);
+  });
+}
+
+function formatDate(date) {
+  const now = new Date();
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 60) return `${diffMins} minute${diffMins !== 1 ? 's' : ''} ago`;
+  if (diffHours < 24) return `${diffHours} hour${diffHours !== 1 ? 's' : ''} ago`;
+  if (diffDays < 7) return `${diffDays} day${diffDays !== 1 ? 's' : ''} ago`;
+
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+async function loadGitHubData(username) {
+  currentGithubUser = username;
+
+  // Show loading state
+  const commitsContainer = document.getElementById('github-commits-container');
+  const chartContainer = document.getElementById('github-chart-container');
+  commitsContainer.innerHTML = '<p class="loading">Loading commits...</p>';
+  chartContainer.innerHTML = '<p class="loading">Loading profile...</p>';
+
+  // Fetch data
+  const [commits, userData] = await Promise.all([
+    fetchGitHubCommits(username),
+    fetchGitHubContributions(username)
+  ]);
+
+  // Render results
+  renderGitHubChart(userData);
+  renderGitHubCommits(commits);
+  renderContestScoreboard();
+}
+
+async function loadAllContestData() {
+  // Load data for both users to populate contest
+  await Promise.all([
+    fetchGitHubCommits('tnielsen2'),
+    fetchGitHubCommits('wheeleruniverse')
+  ]);
+
+  renderContestScoreboard();
+}
+
+function setupGitHubTabs() {
+  const tabs = document.querySelectorAll('.github-tab');
+
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      // Update active state
+      tabs.forEach(t => t.classList.remove('active'));
+      tab.classList.add('active');
+
+      // Load data for selected user
+      const username = tab.getAttribute('data-user');
+      loadGitHubData(username);
+    });
+  });
+}
+
+function setupToggleButton() {
+  const toggleButton = document.getElementById('toggle-github-section');
+  const sectionContent = document.getElementById('github-section-content');
+
+  toggleButton.addEventListener('click', () => {
+    const isCollapsed = sectionContent.classList.toggle('collapsed');
+    const icon = toggleButton.querySelector('i');
+
+    if (isCollapsed) {
+      icon.classList.remove('fa-chevron-up');
+      icon.classList.add('fa-chevron-down');
+    } else {
+      icon.classList.remove('fa-chevron-down');
+      icon.classList.add('fa-chevron-up');
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   populateNewsFeed();
   populateSponsors();
+  setupGitHubTabs();
+  setupToggleButton();
+  loadAllContestData(); // Load both users for contest
+  loadGitHubData('tnielsen2'); // Load default user details
 });
 
 window.onscroll = onScroll;


### PR DESCRIPTION
  Implement a competitive GitHub activity widget that tracks and compares
  commit statistics between tnielsen2 and wheeleruniverse. The feature
  includes a normalized scoring system, collapsible interface, and detailed
  commit visualization.

  Features:
  - 🏆 Contest scoreboard with normalized scoring (60% commits, 40% lines changed)
  - 🔽 Collapsible section with toggle button for better UX
  - ⬇️ Jump-to-newsfeed button for easy navigation
  - 📜 Scrollable commit feed (max 400px height) with custom scrollbar
  - 📊 Real-time commit statistics showing additions/deletions
  - 👤 User profile cards with GitHub stats (repos, followers, following)
  - 🔀 Tab-based navigation between users
  - 📱 Responsive design for mobile and tablet devices
  - 🌟 Winner highlighting with golden gradient and glow effect

  Technical implementation:
  - 🔌 Fetches data from GitHub Events API for recent commits
  - 📡 Fetches detailed commit stats from GitHub Commits API
  - 🧮 Calculates normalized scores using configurable weight formula
  - 🎨 Smooth CSS transitions for collapse/expand animations
  - 🎯 Custom styled scrollbars matching site theme

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

  Co-Authored-By: Claude <noreply@anthropic.com>